### PR TITLE
startDaemon: Validation path give an error 

### DIFF
--- a/src/main/groovy/com/github/kuldeepg/springbootutility/ApplicationSetting.groovy
+++ b/src/main/groovy/com/github/kuldeepg/springbootutility/ApplicationSetting.groovy
@@ -14,11 +14,9 @@ class ApplicationSetting {
     String[] jvmArgs = []
     String name
     String warFile
-    String contextPath
 
     //Application validation properties
-
-    String serverValidationPath 
+    String serverValidationPath =  'health'
 
     Integer maxWait = 120 //in secs
 
@@ -28,9 +26,9 @@ class ApplicationSetting {
         if(jmxPort == -1)
             jmxPort = serverPort + 1
 
-        serverValidationPath = contextPath?.trim() + '/health'
+        if(!ipAddress?.trim())
+            ipAddress = InetAddress.getLocalHost().getHostAddress()
 
-        ipAddress = InetAddress.getLocalHost().getHostAddress()
         validate(this)
     }
 

--- a/src/main/groovy/com/github/kuldeepg/springbootutility/DaemonStartTask.groovy
+++ b/src/main/groovy/com/github/kuldeepg/springbootutility/DaemonStartTask.groovy
@@ -47,13 +47,15 @@ class DaemonStartTask extends DefaultTask {
         Process process = processBuilder.start()
         Integer waitInSecs = settings.maxWait
         String url = new String("http://${settings.ipAddress}:${settings.serverPort}/")
-        
+
+        println "url: ${url}"
         RESTClient client = new RESTClient(url)
         client.getClient().getParams().setParameter("http.connection.timeout", 5000)
         client.getClient().getParams().setParameter("http.socket.timeout", 5000)
 
         while(waitInSecs > 0) {
             try {
+                println "path: ${settings.serverValidationPath}"
                 client.options path: settings.serverValidationPath
                 break
             } catch(ex) {


### PR DESCRIPTION
I had this error: "...daemon couldn't be started", where the validation was "null/health"

- Changed ApplicationSetting.serverValidationPath 

- Set ipAddress as property. In our case the IP InetAddress.getLocalHost().getHostAddress() is the 'external IP' that is not accessible, so now we can put ipAddress="localhost" as property.